### PR TITLE
Icon-friendly edit UI

### DIFF
--- a/app/src/main/java/protect/card_locker/CsvDatabaseExporter.java
+++ b/app/src/main/java/protect/card_locker/CsvDatabaseExporter.java
@@ -51,7 +51,6 @@ public class CsvDatabaseExporter implements DatabaseExporter
                 DBHelper.LoyaltyCardDbIds.NOTE,
                 DBHelper.LoyaltyCardDbIds.CARD_ID,
                 DBHelper.LoyaltyCardDbIds.HEADER_COLOR,
-                DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR,
                 DBHelper.LoyaltyCardDbIds.BARCODE_TYPE,
                 DBHelper.LoyaltyCardDbIds.STAR_STATUS);
 
@@ -66,7 +65,6 @@ public class CsvDatabaseExporter implements DatabaseExporter
                     card.note,
                     card.cardId,
                     card.headerColor,
-                    card.headerTextColor,
                     card.barcodeType,
                     card.starStatus);
 

--- a/app/src/main/java/protect/card_locker/CsvDatabaseImporter.java
+++ b/app/src/main/java/protect/card_locker/CsvDatabaseImporter.java
@@ -274,13 +274,10 @@ public class CsvDatabaseImporter implements DatabaseImporter
         String barcodeType = extractString(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE, record, "");
 
         Integer headerColor = null;
-        Integer headerTextColor = null;
 
-        if(record.isMapped(DBHelper.LoyaltyCardDbIds.HEADER_COLOR) &&
-           record.isMapped(DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR))
+        if(record.isMapped(DBHelper.LoyaltyCardDbIds.HEADER_COLOR))
         {
             headerColor = extractInt(DBHelper.LoyaltyCardDbIds.HEADER_COLOR, record, true);
-            headerTextColor = extractInt(DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR, record, true);
         }
 
         int starStatus = 0;
@@ -291,7 +288,7 @@ public class CsvDatabaseImporter implements DatabaseImporter
             // We catch this exception so we can still import old backups
         }
         if (starStatus != 1) starStatus = 0;
-        helper.insertLoyaltyCard(database, id, store, note, cardId, barcodeType, headerColor, headerTextColor, starStatus);
+        helper.insertLoyaltyCard(database, id, store, note, cardId, barcodeType, headerColor, starStatus);
     }
 
     /**

--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.graphics.Color;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -112,7 +113,7 @@ public class DBHelper extends SQLiteOpenHelper
 
     public long insertLoyaltyCard(final String store, final String note, final String cardId,
                                   final String barcodeType, final Integer headerColor,
-                                  final Integer headerTextColor, final int starStatus)
+                                  final int starStatus)
     {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues contentValues = new ContentValues();
@@ -121,7 +122,7 @@ public class DBHelper extends SQLiteOpenHelper
         contentValues.put(LoyaltyCardDbIds.CARD_ID, cardId);
         contentValues.put(LoyaltyCardDbIds.BARCODE_TYPE, barcodeType);
         contentValues.put(LoyaltyCardDbIds.HEADER_COLOR, headerColor);
-        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, headerTextColor);
+        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, Color.WHITE);
         contentValues.put(LoyaltyCardDbIds.STAR_STATUS, starStatus);
         final long newId = db.insert(LoyaltyCardDbIds.TABLE, null, contentValues);
         return newId;
@@ -130,7 +131,7 @@ public class DBHelper extends SQLiteOpenHelper
     public boolean insertLoyaltyCard(final SQLiteDatabase db, final int id, final String store,
                                      final String note, final String cardId,
                                      final String barcodeType, final Integer headerColor,
-                                     final Integer headerTextColor, final int starStatus)
+                                     final int starStatus)
     {
         ContentValues contentValues = new ContentValues();
         contentValues.put(LoyaltyCardDbIds.ID, id);
@@ -139,7 +140,7 @@ public class DBHelper extends SQLiteOpenHelper
         contentValues.put(LoyaltyCardDbIds.CARD_ID, cardId);
         contentValues.put(LoyaltyCardDbIds.BARCODE_TYPE, barcodeType);
         contentValues.put(LoyaltyCardDbIds.HEADER_COLOR, headerColor);
-        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, headerTextColor);
+        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, Color.WHITE);
         contentValues.put(LoyaltyCardDbIds.STAR_STATUS,starStatus);
         final long newId = db.insert(LoyaltyCardDbIds.TABLE, null, contentValues);
         return (newId != -1);
@@ -147,7 +148,7 @@ public class DBHelper extends SQLiteOpenHelper
 
     public boolean updateLoyaltyCard(final int id, final String store, final String note,
                                      final String cardId, final String barcodeType,
-                                     final Integer headerColor, final Integer headerTextColor)
+                                     final Integer headerColor)
     {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues contentValues = new ContentValues();
@@ -156,7 +157,7 @@ public class DBHelper extends SQLiteOpenHelper
         contentValues.put(LoyaltyCardDbIds.CARD_ID, cardId);
         contentValues.put(LoyaltyCardDbIds.BARCODE_TYPE, barcodeType);
         contentValues.put(LoyaltyCardDbIds.HEADER_COLOR, headerColor);
-        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, headerTextColor);
+        contentValues.put(LoyaltyCardDbIds.HEADER_TEXT_COLOR, Color.WHITE);
         int rowsUpdated = db.update(LoyaltyCardDbIds.TABLE, contentValues,
                 LoyaltyCardDbIds.ID + "=?",
                 new String[]{Integer.toString(id)});

--- a/app/src/main/java/protect/card_locker/ImportURIHelper.java
+++ b/app/src/main/java/protect/card_locker/ImportURIHelper.java
@@ -12,9 +12,6 @@ public class ImportURIHelper {
     private static final String BARCODE_TYPE = DBHelper.LoyaltyCardDbIds.BARCODE_TYPE;
 
     private static final String HEADER_COLOR = DBHelper.LoyaltyCardDbIds.HEADER_COLOR;
-    private static final String HEADER_TEXT_COLOR = DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR;
-
-
 
     private final Context context;
     private final String host;
@@ -57,11 +54,6 @@ public class ImportURIHelper {
             {
                 headerColor = Integer.parseInt(unparsedHeaderColor);
             }
-            String unparsedHeaderTextColor = uri.getQueryParameter(HEADER_TEXT_COLOR);
-            if(unparsedHeaderTextColor != null)
-            {
-                headerTextColor = Integer.parseInt(unparsedHeaderTextColor);
-            }
 
             return new LoyaltyCard(-1, store, note, cardId, barcodeType, headerColor, headerTextColor, 0);
         } catch (NullPointerException | NumberFormatException ex) {
@@ -82,10 +74,6 @@ public class ImportURIHelper {
         if(loyaltyCard.headerColor != null)
         {
             uriBuilder.appendQueryParameter(HEADER_COLOR, loyaltyCard.headerColor.toString());
-        }
-        if(loyaltyCard.headerTextColor != null)
-        {
-            uriBuilder.appendQueryParameter(HEADER_TEXT_COLOR, loyaltyCard.headerTextColor.toString());
         }
         //StarStatus will not be exported
         return uriBuilder.build();

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -71,13 +71,6 @@ class LoyaltyCardCursorAdapter extends CursorAdapter
         if (loyaltyCard.starStatus!=0) star.setVisibility(View.VISIBLE);
             else star.setVisibility(View.GONE);
 
-        int tileLetterFontSize = context.getResources().getDimensionPixelSize(R.dimen.tileLetterFontSize);
-        int pixelSize = context.getResources().getDimensionPixelSize(R.dimen.cardThumbnailSize);
-
-        Integer letterBackgroundColor = loyaltyCard.headerColor;
-        Integer letterTextColor = loyaltyCard.headerTextColor;
-        LetterBitmap letterBitmap = new LetterBitmap(context, loyaltyCard.store, loyaltyCard.store,
-                tileLetterFontSize, pixelSize, pixelSize, letterBackgroundColor, letterTextColor);
-        thumbnail.setImageBitmap(letterBitmap.getLetterTile());
+        thumbnail.setImageBitmap(Utils.generateIcon(context, loyaltyCard.store, loyaltyCard.headerColor, loyaltyCard.headerTextColor).getLetterTile());
     }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -71,6 +71,6 @@ class LoyaltyCardCursorAdapter extends CursorAdapter
         if (loyaltyCard.starStatus!=0) star.setVisibility(View.VISIBLE);
             else star.setVisibility(View.GONE);
 
-        thumbnail.setImageBitmap(Utils.generateIcon(context, loyaltyCard.store, loyaltyCard.headerColor, loyaltyCard.headerTextColor).getLetterTile());
+        thumbnail.setImageBitmap(Utils.generateIcon(context, loyaltyCard.store, loyaltyCard.headerColor).getLetterTile());
     }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -357,12 +357,12 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
 
         if(cardIdFieldView.getText().length() > 0)
         {
-            cardIdFieldView.setVisibility(View.VISIBLE);
+            cardAndBarcodeLayout.setVisibility(View.VISIBLE);
             enterButton.setText(R.string.editCard);
         }
         else
         {
-            cardIdFieldView.setVisibility(View.GONE);
+            cardAndBarcodeLayout.setVisibility(View.GONE);
             enterButton.setText(R.string.enterCard);
         }
 
@@ -571,15 +571,11 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     }
 
     private void showBarcode() {
-        cardAndBarcodeLayout.setVisibility(View.VISIBLE);
         barcodeImageLayout.setVisibility(View.VISIBLE);
-        findViewById(R.id.barcodeTypeView).setVisibility(View.VISIBLE);
     }
 
     private void hideBarcode() {
         barcodeImageLayout.setVisibility(View.GONE);
-        cardAndBarcodeLayout.setVisibility(View.GONE);
-        findViewById(R.id.barcodeTypeView).setVisibility(View.GONE);
     }
 
     private void generateIcon(String store) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -17,7 +17,11 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -45,17 +49,13 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
 
     protected static final int SELECT_BARCODE_REQUEST = 1;
 
+    ImageView thumbnail;
     EditText storeFieldEdit;
     EditText noteFieldEdit;
     ChipGroup groupsChips;
-    ImageView headingColorSample;
-    Button headingColorSelectButton;
-    ImageView headingStoreTextColorSample;
-    Button headingStoreTextColorSelectButton;
+    View cardAndBarcodeLayout;
     TextView cardIdFieldView;
-    View cardIdDivider;
-    View cardIdTableRow;
-    TextView barcodeTypeField;
+    EditText barcodeTypeField;
     ImageView barcodeImage;
     View barcodeImageLayout;
     View barcodeCaptureLayout;
@@ -102,23 +102,32 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
         db = new DBHelper(this);
         importUriHelper = new ImportURIHelper(this);
 
+        thumbnail = findViewById(R.id.thumbnail);
         storeFieldEdit = findViewById(R.id.storeNameEdit);
         noteFieldEdit = findViewById(R.id.noteEdit);
         groupsChips = findViewById(R.id.groupChips);
-        headingColorSample = findViewById(R.id.headingColorSample);
-        headingColorSelectButton = findViewById(R.id.headingColorSelectButton);
-        headingStoreTextColorSample = findViewById(R.id.headingStoreTextColorSample);
-        headingStoreTextColorSelectButton = findViewById(R.id.headingStoreTextColorSelectButton);
+        cardAndBarcodeLayout = findViewById(R.id.cardAndBarcodeLayout);
         cardIdFieldView = findViewById(R.id.cardIdView);
-        cardIdDivider = findViewById(R.id.cardIdDivider);
-        cardIdTableRow = findViewById(R.id.cardIdTableRow);
-        barcodeTypeField = findViewById(R.id.barcodeTypeView);
+        barcodeTypeField = findViewById(R.id.barcodeTypeField);
         barcodeImage = findViewById(R.id.barcode);
         barcodeImageLayout = findViewById(R.id.barcodeLayout);
         barcodeCaptureLayout = findViewById(R.id.barcodeCaptureLayout);
 
         captureButton = findViewById(R.id.captureButton);
         enterButton = findViewById(R.id.enterButton);
+
+        storeFieldEdit.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                generateIcon(s.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) { }
+        });
     }
 
     @Override
@@ -225,15 +234,10 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
 
             List<Group> loyaltyCardGroups = db.getLoyaltyCardGroups(loyaltyCardId);
 
-            View groupsView = findViewById(R.id.groupsView);
-            View groupsTableRow = findViewById(R.id.groupsTableRow);
-
             if (existingGroups.isEmpty()) {
-                groupsView.setVisibility(View.GONE);
-                groupsTableRow.setVisibility(View.GONE);
+                groupsChips.setVisibility(View.GONE);
             } else {
-                groupsView.setVisibility(View.VISIBLE);
-                groupsTableRow.setVisibility(View.VISIBLE);
+                groupsChips.setVisibility(View.VISIBLE);
             }
 
             for (Group group : db.getGroups()) {
@@ -266,10 +270,7 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
             headingStoreTextColorValue = Color.WHITE;
         }
 
-        headingColorSample.setBackgroundColor(headingColorValue);
-        headingStoreTextColorSample.setBackgroundColor(headingStoreTextColorValue);
-        headingColorSelectButton.setOnClickListener(new ColorSelectListener(headingColorValue, true));
-        headingStoreTextColorSelectButton.setOnClickListener(new ColorSelectListener(headingStoreTextColorValue, false));
+        thumbnail.setOnClickListener(new ColorSelectListener(headingColorValue, true));
 
         if(cardIdFieldView.getText().length() > 0 && barcodeTypeField.getText().length() > 0)
         {
@@ -356,14 +357,12 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
 
         if(cardIdFieldView.getText().length() > 0)
         {
-            cardIdDivider.setVisibility(View.VISIBLE);
-            cardIdTableRow.setVisibility(View.VISIBLE);
+            cardIdFieldView.setVisibility(View.VISIBLE);
             enterButton.setText(R.string.editCard);
         }
         else
         {
-            cardIdDivider.setVisibility(View.GONE);
-            cardIdTableRow.setVisibility(View.GONE);
+            cardIdFieldView.setVisibility(View.GONE);
             enterButton.setText(R.string.enterCard);
         }
 
@@ -374,6 +373,8 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
                 doSave();
             }
         });
+
+        generateIcon(storeFieldEdit.getText().toString());
     }
 
     class ColorSelectListener implements View.OnClickListener
@@ -398,14 +399,14 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
                 {
                     if(isBackgroundColor)
                     {
-                        headingColorSample.setBackgroundColor(color);
                         headingColorValue = color;
                     }
                     else
                     {
-                        headingStoreTextColorSample.setBackgroundColor(color);
                         headingStoreTextColorValue = color;
                     }
+
+                    generateIcon(storeFieldEdit.getText().toString());
                 }
 
                 @Override
@@ -570,14 +571,32 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     }
 
     private void showBarcode() {
+        cardAndBarcodeLayout.setVisibility(View.VISIBLE);
         barcodeImageLayout.setVisibility(View.VISIBLE);
-        findViewById(R.id.barcodeTypeDivider).setVisibility(View.VISIBLE);
-        findViewById(R.id.barcodeTypeTableRow).setVisibility(View.VISIBLE);
+        findViewById(R.id.barcodeTypeView).setVisibility(View.VISIBLE);
     }
 
     private void hideBarcode() {
         barcodeImageLayout.setVisibility(View.GONE);
-        findViewById(R.id.barcodeTypeDivider).setVisibility(View.GONE);
-        findViewById(R.id.barcodeTypeTableRow).setVisibility(View.GONE);
+        cardAndBarcodeLayout.setVisibility(View.GONE);
+        findViewById(R.id.barcodeTypeView).setVisibility(View.GONE);
+    }
+
+    private void generateIcon(String store) {
+        if (headingColorValue == null && headingStoreTextColorValue == null) {
+            return;
+        }
+
+        thumbnail.setBackgroundColor(headingColorValue);
+
+        LetterBitmap letterBitmap = Utils.generateIcon(this, store, headingColorValue, headingStoreTextColorValue);
+
+        if (letterBitmap != null) {
+            thumbnail.setImageBitmap(letterBitmap.getLetterTile());
+        } else {
+            thumbnail.setImageBitmap(null);
+        }
+
+        thumbnail.setMinimumWidth(thumbnail.getHeight());
     }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -67,7 +67,6 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     boolean updateLoyaltyCard;
     Uri importLoyaltyCardUri = null;
     Integer headingColorValue = null;
-    Integer headingStoreTextColorValue = null;
 
     DBHelper db;
     ImportURIHelper importUriHelper;
@@ -192,15 +191,6 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
                 }
             }
 
-            if(headingStoreTextColorValue == null)
-            {
-                headingStoreTextColorValue = loyaltyCard.headerTextColor;
-                if(headingStoreTextColorValue == null)
-                {
-                    headingStoreTextColorValue = Color.WHITE;
-                }
-            }
-
             setTitle(R.string.editCardTitle);
         }
         else if(importLoyaltyCardUri != null)
@@ -220,7 +210,6 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
             cardIdFieldView.setText(importCard.cardId);
             barcodeTypeField.setText(importCard.barcodeType);
             headingColorValue = importCard.headerColor;
-            headingStoreTextColorValue = importCard.headerTextColor;
         }
         else
         {
@@ -266,11 +255,7 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
             colors.recycle();
         }
 
-        if(headingStoreTextColorValue == null) {
-            headingStoreTextColorValue = Color.WHITE;
-        }
-
-        thumbnail.setOnClickListener(new ColorSelectListener(headingColorValue, true));
+        thumbnail.setOnClickListener(new ColorSelectListener(headingColorValue));
 
         if(cardIdFieldView.getText().length() > 0 && barcodeTypeField.getText().length() > 0)
         {
@@ -380,12 +365,10 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     class ColorSelectListener implements View.OnClickListener
     {
         final int defaultColor;
-        final boolean isBackgroundColor;
 
-        ColorSelectListener(int defaultColor, boolean isBackgroundColor)
+        ColorSelectListener(int defaultColor)
         {
             this.defaultColor = defaultColor;
-            this.isBackgroundColor = isBackgroundColor;
         }
 
         @Override
@@ -397,14 +380,7 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
                 @Override
                 public void onColorSelected(int dialogId, int color)
                 {
-                    if(isBackgroundColor)
-                    {
-                        headingColorValue = color;
-                    }
-                    else
-                    {
-                        headingStoreTextColorValue = color;
-                    }
+                    headingColorValue = color;
 
                     generateIcon(storeFieldEdit.getText().toString());
                 }
@@ -454,12 +430,12 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
 
         if(updateLoyaltyCard)
         {   //update of "starStatus" not necessary, since it cannot be changed in this activity (only in ViewActivity)
-            db.updateLoyaltyCard(loyaltyCardId, store, note, cardId, barcodeType, headingColorValue, headingStoreTextColorValue);
+            db.updateLoyaltyCard(loyaltyCardId, store, note, cardId, barcodeType, headingColorValue);
             Log.i(TAG, "Updated " + loyaltyCardId + " to " + cardId);
         }
         else
         {
-            loyaltyCardId = (int)db.insertLoyaltyCard(store, note, cardId, barcodeType, headingColorValue, headingStoreTextColorValue, 0);
+            loyaltyCardId = (int)db.insertLoyaltyCard(store, note, cardId, barcodeType, headingColorValue, 0);
         }
 
         db.setLoyaltyCardGroups(loyaltyCardId, selectedGroups);
@@ -579,13 +555,13 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     }
 
     private void generateIcon(String store) {
-        if (headingColorValue == null && headingStoreTextColorValue == null) {
+        if (headingColorValue == null) {
             return;
         }
 
         thumbnail.setBackgroundColor(headingColorValue);
 
-        LetterBitmap letterBitmap = Utils.generateIcon(this, store, headingColorValue, headingStoreTextColorValue);
+        LetterBitmap letterBitmap = Utils.generateIcon(this, store, headingColorValue);
 
         if (letterBitmap != null) {
             thumbnail.setImageBitmap(letterBitmap.getLetterTile());

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -210,7 +210,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         collapsingToolbarLayout.setBackgroundColor(backgroundHeaderColor);
 
         int textColor;
-        if(Utils.needsDarkForeground(loyaltyCard.headerColor))
+        if(Utils.needsDarkForeground(backgroundHeaderColor))
         {
             textColor = Color.BLACK;
         }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -197,17 +197,6 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         storeName.setText(loyaltyCard.store);
         storeName.setTextSize(settings.getCardTitleFontSize());
 
-        int textColor;
-        if(loyaltyCard.headerTextColor != null)
-        {
-            textColor = loyaltyCard.headerTextColor;
-        }
-        else
-        {
-            textColor = Color.WHITE;
-        }
-        storeName.setTextColor(textColor);
-
         int backgroundHeaderColor;
         if(loyaltyCard.headerColor != null)
         {
@@ -219,6 +208,17 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         }
 
         collapsingToolbarLayout.setBackgroundColor(backgroundHeaderColor);
+
+        int textColor;
+        if(Utils.needsDarkForeground(loyaltyCard.headerColor))
+        {
+            textColor = Color.BLACK;
+        }
+        else
+        {
+            textColor = Color.WHITE;
+        }
+        storeName.setTextColor(textColor);
 
         // If the background is very bright, we should use dark icons
         backgroundNeedsDarkIcons = Utils.needsDarkForeground(backgroundHeaderColor);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -8,7 +8,6 @@ import android.os.Build;
 import android.os.Bundle;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.widget.TextViewCompat;
 import androidx.appcompat.app.ActionBar;
@@ -36,7 +35,6 @@ import protect.card_locker.preferences.Settings;
 public class LoyaltyCardViewActivity extends AppCompatActivity
 {
     private static final String TAG = "Catima";
-    private static final double LUMINANCE_MIDPOINT = 0.5;
 
     TextView cardIdFieldView;
     TextView noteView;
@@ -223,7 +221,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         collapsingToolbarLayout.setBackgroundColor(backgroundHeaderColor);
 
         // If the background is very bright, we should use dark icons
-        backgroundNeedsDarkIcons = (ColorUtils.calculateLuminance(backgroundHeaderColor) > LUMINANCE_MIDPOINT);
+        backgroundNeedsDarkIcons = Utils.needsDarkForeground(backgroundHeaderColor);
         ActionBar actionBar = getSupportActionBar();
         if(actionBar != null)
         {

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -486,5 +486,4 @@ public class MainActivity extends AppCompatActivity
         int currentNightMode = config.uiMode & Configuration.UI_MODE_NIGHT_MASK;
         return (currentNightMode == Configuration.UI_MODE_NIGHT_YES);
     }
-
 }

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -1,0 +1,17 @@
+package protect.card_locker;
+
+import android.content.Context;
+
+public class Utils {
+    static public LetterBitmap generateIcon(Context context, String store, Integer backgroundColor, Integer textColor) {
+        if (store.length() == 0) {
+            return null;
+        }
+
+        int tileLetterFontSize = context.getResources().getDimensionPixelSize(R.dimen.tileLetterFontSize);
+        int pixelSize = context.getResources().getDimensionPixelSize(R.dimen.cardThumbnailSize);
+
+        return new LetterBitmap(context, store, store,
+                tileLetterFontSize, pixelSize, pixelSize, backgroundColor, textColor);
+    }
+}

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -1,9 +1,14 @@
 package protect.card_locker;
 
 import android.content.Context;
+import android.graphics.Color;
+
+import androidx.core.graphics.ColorUtils;
 
 public class Utils {
-    static public LetterBitmap generateIcon(Context context, String store, Integer backgroundColor, Integer textColor) {
+    static final double LUMINANCE_MIDPOINT = 0.5;
+
+    static public LetterBitmap generateIcon(Context context, String store, Integer backgroundColor) {
         if (store.length() == 0) {
             return null;
         }
@@ -12,6 +17,10 @@ public class Utils {
         int pixelSize = context.getResources().getDimensionPixelSize(R.dimen.cardThumbnailSize);
 
         return new LetterBitmap(context, store, store,
-                tileLetterFontSize, pixelSize, pixelSize, backgroundColor, textColor);
+                tileLetterFontSize, pixelSize, pixelSize, backgroundColor, needsDarkForeground(backgroundColor) ? Color.BLACK : Color.WHITE);
+    }
+
+    static public boolean needsDarkForeground(Integer backgroundColor) {
+        return ColorUtils.calculateLuminance(backgroundColor) > LUMINANCE_MIDPOINT;
     }
 }

--- a/app/src/main/res/layout/loyalty_card_edit_activity.xml
+++ b/app/src/main/res/layout/loyalty_card_edit_activity.xml
@@ -32,478 +32,193 @@
                 android:layout_height="wrap_content"
                 android:background="@color/inputContrastBackground"
                 app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-        <LinearLayout
+        <TableLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
-            <TableLayout android:layout_width="fill_parent"
-                         android:layout_height="wrap_content"
-                         android:shrinkColumns="1"
-                         android:background="@color/inputContrastBackground">
 
-                <!-- Store Name -->
-                <View
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
+            <!-- Store -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="@dimen/inputPadding"
+                android:paddingTop="@dimen/inputPadding"
+                android:orientation="horizontal">
 
-                    <RelativeLayout
-                        android:layout_weight="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
+                <androidx.cardview.widget.CardView
+                    android:layout_width="@dimen/cardThumbnailSize"
+                    android:layout_height="@dimen/cardThumbnailSize"
+                    android:layout_marginEnd="@dimen/activity_margin"
+                    android:layout_marginRight="@dimen/activity_margin"
+                    android:layout_gravity="center_vertical"
+                    app:cardCornerRadius="4dp"
+                    android:paddingHorizontal="@dimen/inputPadding"
+                    app:cardElevation="0dp">
 
-                        <TextView
-                            android:id="@+id/storeNameField"
-                            android:text="@string/storeName"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"/>
+                    <ImageView
+                        android:id="@+id/thumbnail"
+                        android:layout_width="@dimen/cardThumbnailSize"
+                        android:layout_height="@dimen/cardThumbnailSize"
+                        android:contentDescription="@string/thumbnailDescription"
+                        android:src="@mipmap/ic_launcher"/>
 
-                        <EditText
-                            android:id="@+id/storeNameEdit"
-                            android:inputType="textCapWords"
-                            android:layout_height="wrap_content"
-                            android:layout_width="match_parent"
-                            android:padding="@dimen/inputPadding"
-                            android:textSize="@dimen/inputSize"
-                            android:layout_toEndOf="@id/storeNameField"
-                            android:layout_toRightOf="@id/storeNameField"
-                            />
+                </androidx.cardview.widget.CardView>
 
-                    </RelativeLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <!-- Note -->
-                <View
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-
-                    <RelativeLayout
-                        android:layout_weight="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
-
-                        <TextView
-                            android:id="@+id/noteField"
-                            android:text="@string/note"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            />
-
-                        <EditText
-                            android:id="@+id/noteEdit"
-                            android:inputType="textMultiLine"
-                            android:layout_height="wrap_content"
-                            android:layout_width="match_parent"
-                            android:padding="@dimen/inputPadding"
-                            android:textSize="@dimen/inputSize"
-                            android:layout_toEndOf="@id/noteField"
-                            android:layout_toRightOf="@id/noteField"
-                            />
-                    </RelativeLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <!-- Groups -->
-                <View
-                    android:id="@+id/groupsView"
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder"
-                    android:visibility="gone"/>
-                <TableRow
-                    android:id="@+id/groupsTableRow"
-                    android:background="@color/inputBackground"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/storeNameField"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
+                    android:hint="@string/storeName">
 
-                    <RelativeLayout
-                        android:layout_weight="1"
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/storeNameEdit"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
+                        />
 
-                        <TextView
-                            android:id="@+id/groupsField"
-                            android:text="@string/groups"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
 
-                        <com.google.android.material.chip.ChipGroup
-                            android:id="@+id/groupChips"
-                            android:layout_height="match_parent"
-                            android:layout_width="match_parent"
-                            android:padding="@dimen/inputPadding"
-                            android:textSize="@dimen/inputSize"
-                            android:layout_toEndOf="@id/groupsField"
-                            android:layout_toRightOf="@id/groupsField"
-                            />
-                    </RelativeLayout>
+            <!-- Note -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="@dimen/inputPadding"
+                android:paddingTop="@dimen/inputPadding"
+                android:orientation="horizontal">
 
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-
-                <!-- Store Header Background Color -->
-                <View
-                    android:layout_height="@dimen/inputBorderThickness"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/noteField"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
+                    android:layout_height="wrap_content"
+                    android:hint="@string/note">
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_weight="1"
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/noteEdit"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
+                        />
 
-                        <TextView
-                            android:id="@+id/headingField"
-                            android:text="@string/storeTextBackgroundColorTitle"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            app:layout_constraintStart_toStartOf="parent"/>
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
 
-                        <androidx.constraintlayout.widget.ConstraintLayout
-                            android:id="@+id/headingColorSampleBorder"
-                            android:layout_width="0dp"
-                            android:layout_height="0dp"
-                            android:layout_margin="@dimen/colorSamplePadding"
-                            app:layout_constraintStart_toEndOf="@id/headingField"
-                            app:layout_constraintEnd_toStartOf="@+id/headingColorSelectButton"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            android:background="@android:color/black">
-                            <ImageView
-                                android:id="@+id/headingColorSample"
-                                android:layout_width="0dp"
-                                android:layout_height="0dp"
-                                android:layout_margin="1dp"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintEnd_toEndOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintBottom_toBottomOf="parent"
-                                android:background="@android:color/white"
-                                android:contentDescription="@string/storeNameBackgroundColorDescription"/>
-                        </androidx.constraintlayout.widget.ConstraintLayout>
+            <!-- Group -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="@dimen/inputPadding"
+                android:paddingTop="@dimen/inputPadding"
+                android:orientation="horizontal">
 
-                       <Button
-                           android:id="@+id/headingColorSelectButton"
-                           android:text="@string/change"
-                           android:padding="@dimen/inputPadding"
-                           android:layout_width="wrap_content"
-                           android:layout_height="match_parent"
-                           android:layout_toEndOf="@id/headingColorSampleBorder"
-                           android:layout_toRightOf="@id/headingColorSampleBorder"
-                           app:layout_constraintEnd_toEndOf="parent"/>
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <!-- Store Text Color -->
-                <View
-                    android:layout_height="@dimen/inputBorderThickness"
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/groupChips"
+                    android:layout_height="match_parent"
                     android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
+                    android:padding="@dimen/inputPadding"
+                    android:textSize="@dimen/inputSize" />
+            </LinearLayout>
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_weight="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
-
-                        <TextView
-                            android:id="@+id/storeTextField"
-                            android:text="@string/storeTextColorTitle"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            app:layout_constraintStart_toStartOf="parent"/>
-
-                        <androidx.constraintlayout.widget.ConstraintLayout
-                            android:id="@+id/headingStoreTextColorSampleBorder"
-                            android:layout_width="0dp"
-                            android:layout_height="0dp"
-                            android:layout_margin="@dimen/colorSamplePadding"
-                            app:layout_constraintStart_toEndOf="@id/storeTextField"
-                            app:layout_constraintEnd_toStartOf="@+id/headingStoreTextColorSelectButton"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            android:background="@android:color/black">
-                            <ImageView
-                                android:id="@+id/headingStoreTextColorSample"
-                                android:layout_width="0dp"
-                                android:layout_height="0dp"
-                                android:layout_margin="1dp"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintEnd_toEndOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintBottom_toBottomOf="parent"
-                                android:background="@android:color/white"
-                                android:contentDescription="@string/storeNameColorDescription"/>
-                        </androidx.constraintlayout.widget.ConstraintLayout>
-
-                        <Button
-                            android:id="@+id/headingStoreTextColorSelectButton"
-                            android:text="@string/change"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_width="wrap_content"
-                            android:layout_height="match_parent"
-                            android:layout_toEndOf="@id/headingStoreTextColorSampleBorder"
-                            android:layout_toRightOf="@id/headingStoreTextColorSampleBorder"
-                            app:layout_constraintEnd_toEndOf="parent"/>
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <!-- Card ID -->
-                <View
-                    android:id="@+id/cardIdDivider"
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:id="@+id/cardIdTableRow"
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-
-                    <RelativeLayout
-                        android:orientation="horizontal"
-                        android:layout_weight="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
-
-                        <TextView
-                            android:id="@+id/cardIdField"
-                            android:text="@string/cardId"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            />
-
-                        <TextView
-                            android:id="@+id/cardIdView"
-                            android:layout_height="wrap_content"
-                            android:layout_width="match_parent"
-                            android:padding="@dimen/inputPadding"
-                            android:textSize="@dimen/inputSize"
-                            android:textIsSelectable="true"
-                            android:layout_toEndOf="@id/cardIdField"
-                            android:layout_toRightOf="@id/cardIdField"
-                            />
-                    </RelativeLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <!-- Barcode Type -->
-                <View
-                    android:id="@+id/barcodeTypeDivider"
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-                <TableRow
-                    android:id="@+id/barcodeTypeTableRow"
-                    android:background="@color/inputBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <View
-                        android:gravity="start"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-
-                    <RelativeLayout
-                        android:orientation="horizontal"
-                        android:layout_weight="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="@dimen/inputPadding"
-                        android:paddingEnd="@dimen/inputPadding">
-
-                        <TextView
-                            android:id="@+id/barcodeTypeField"
-                            android:text="@string/barcodeType"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"
-                            android:textSize="@dimen/inputSize"
-                            android:padding="@dimen/inputPadding"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            />
-
-                        <TextView
-                            android:id="@+id/barcodeTypeView"
-                            android:layout_height="wrap_content"
-                            android:layout_width="match_parent"
-                            android:padding="@dimen/inputPadding"
-                            android:textSize="@dimen/inputSize"
-                            android:textIsSelectable="true"
-                            android:layout_toEndOf="@id/barcodeTypeField"
-                            android:layout_toRightOf="@id/barcodeTypeField"
-                            />
-                    </RelativeLayout>
-
-                    <View
-                        android:gravity="end"
-                        android:layout_height="match_parent"
-                        android:layout_width="@dimen/inputBorderThickness"
-                        android:background="@color/inputBorder" />
-                </TableRow>
-
-                <View
-                    android:layout_height="@dimen/inputBorderThickness"
-                    android:layout_width="match_parent"
-                    android:background="@color/inputBorder" />
-
-                <LinearLayout android:orientation="horizontal"
-                              android:padding="10.0dip"
-                              android:layout_width="fill_parent"
-                              android:layout_height="wrap_content"
-                              android:visibility="gone"
-                              android:id="@+id/barcodeLayout">
-                    <ImageView
-                        android:layout_width="0dp"
-                        android:layout_height="@dimen/barcode_disp_height"
-                        android:layout_gravity="center_horizontal"
-                        android:padding="10.0dp"
-                        android:background="#ffffff"
-                        android:id="@+id/barcode"
-                        android:contentDescription="@string/barcodeImageDescription"
-                        android:layout_weight="1.0"/>
-                </LinearLayout>
+            <!-- Buttons -->
+            <TableLayout android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:shrinkColumns="1"
+                android:background="@color/inputContrastBackground">
 
                 <LinearLayout android:orientation="vertical"
-                              android:layout_width="fill_parent"
-                              android:layout_height="wrap_content"
-                              android:background="@color/inputBackground">
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/inputBackground">
 
                     <LinearLayout android:orientation="horizontal"
-                                  android:padding="10.0dip"
-                                  android:layout_width="fill_parent"
-                                  android:layout_height="wrap_content"
-                                  android:id="@+id/barcodeCaptureLayout">
+                        android:padding="10.0dip"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/barcodeCaptureLayout">
                         <Button android:id="@+id/captureButton"
-                                android:layout_margin="@dimen/inputMargin"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:text="@string/capture"
-                                android:layout_weight="1.0"/>
+                            android:layout_margin="@dimen/inputMargin"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:text="@string/capture"
+                            android:layout_weight="1.0"/>
                         <Button android:id="@+id/enterButton"
-                                android:layout_margin="@dimen/inputMargin"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:text="@string/enterCard"
-                                android:layout_weight="1.0"/>
+                            android:layout_margin="@dimen/inputMargin"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:text="@string/enterCard"
+                            android:layout_weight="1.0"/>
                     </LinearLayout>
                 </LinearLayout>
-
             </TableLayout>
-        </LinearLayout>
+
+            <!-- Card ID and Barcode type -->
+            <LinearLayout
+                android:id="@+id/cardAndBarcodeLayout"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="@dimen/inputPadding"
+                android:paddingTop="@dimen/inputPadding"
+                android:orientation="horizontal">
+
+                <!-- Card ID -->
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/cardIdField"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.0"
+                    android:hint="@string/cardId">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/cardIdView"
+                        android:inputType="none"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <!-- Barcode type -->
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/barcodeTypeView"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.0"
+                    android:hint="@string/barcodeType">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/barcodeTypeField"
+                        android:inputType="none"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+            <!-- Barcode -->
+            <View
+                android:layout_height="@dimen/inputBorderThickness"
+                android:layout_width="match_parent" />
+
+            <LinearLayout android:orientation="horizontal"
+                          android:padding="10.0dip"
+                          android:layout_width="fill_parent"
+                          android:layout_height="wrap_content"
+                          android:visibility="gone"
+                          android:id="@+id/barcodeLayout">
+                <ImageView
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/barcode_disp_height"
+                    android:layout_gravity="center_horizontal"
+                    android:padding="10.0dp"
+                    android:background="#ffffff"
+                    android:id="@+id/barcode"
+                    android:contentDescription="@string/barcodeImageDescription"
+                    android:layout_weight="1.0"/>
+            </LinearLayout>
+        </TableLayout>
     </ScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/loyalty_card_edit_activity.xml
+++ b/app/src/main/res/layout/loyalty_card_edit_activity.xml
@@ -172,7 +172,6 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/cardIdView"
-                        android:inputType="none"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         />
@@ -182,18 +181,17 @@
                 <!-- Barcode type -->
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/barcodeTypeView"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.0"
                     android:hint="@string/barcodeType">
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <AutoCompleteTextView
                         android:id="@+id/barcodeTypeField"
-                        android:inputType="none"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        />
+                        android:inputType="none"/>
                 </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -22,7 +22,7 @@
     <dimen name="inputBorderThickness">2dip</dimen>
     <dimen name="inputBorderDividerThickness">4dip</dimen>
     <dimen name="inputMargin">2dip</dimen>
-    <dimen name="inputPadding">20dip</dimen>
+    <dimen name="inputPadding">10dip</dimen>
     <dimen name="colorSamplePadding">10dip</dimen>
     <dimen name="inputSize">18sp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="cardId">Card ID</string>
     <string name="barcodeType">Barcode type</string>
     <string name="barcodeNoBarcode">This card has no barcode</string>
+    <string name="noBarcode">No barcode</string>
 
     <string name="star">Add to favorites</string>
     <string name="unstar">Remove from favorites</string>

--- a/app/src/test/java/protect/card_locker/DatabaseTest.java
+++ b/app/src/test/java/protect/card_locker/DatabaseTest.java
@@ -44,7 +44,7 @@ public class DatabaseTest
     public void addRemoveOneGiftCard()
     {
         assertEquals(0, db.getLoyaltyCardCount());
-        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR, 0);
+        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());
@@ -66,12 +66,12 @@ public class DatabaseTest
     @Test
     public void updateGiftCard()
     {
-        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR,0);
+        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());
 
-        result = db.updateLoyaltyCard(1, "store1", "note1", "cardId1", BarcodeFormat.AZTEC.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR);
+        result = db.updateLoyaltyCard(1, "store1", "note1", "cardId1", BarcodeFormat.AZTEC.toString(), DEFAULT_HEADER_COLOR);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());
 
@@ -87,7 +87,7 @@ public class DatabaseTest
     @Test
     public void updateGiftCardOnlyStar()
     {
-        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR,0);
+        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());
@@ -111,7 +111,7 @@ public class DatabaseTest
         assertEquals(0, db.getLoyaltyCardCount());
 
         boolean result = db.updateLoyaltyCard(1, "store1", "note1", "cardId1",
-                BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR);
+                BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR);
         assertEquals(false, result);
         assertEquals(0, db.getLoyaltyCardCount());
     }
@@ -119,7 +119,7 @@ public class DatabaseTest
     @Test
     public void emptyGiftCardValues()
     {
-        long id = db.insertLoyaltyCard("", "", "", "", null, null, 0);
+        long id = db.insertLoyaltyCard("", "", "", "", null, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());
@@ -142,7 +142,7 @@ public class DatabaseTest
         for(int index = CARDS_TO_ADD-1; index >= 0; index--)
         {
             long id = db.insertLoyaltyCard("store" + index, "note" + index, "cardId" + index,
-                    BarcodeFormat.UPC_A.toString(), index, index*2, 0);
+                    BarcodeFormat.UPC_A.toString(), index, 0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -165,7 +165,6 @@ public class DatabaseTest
             assertEquals(BarcodeFormat.UPC_A.toString(), cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE)));
             assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS)));
             assertEquals(index, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR)));
-            assertEquals(index*2, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR)));
 
             cursor.moveToNext();
         }
@@ -184,12 +183,12 @@ public class DatabaseTest
         {
             if (index == CARDS_TO_ADD-1) {
                 id = db.insertLoyaltyCard("store" + index, "note" + index, "cardId" + index,
-                        BarcodeFormat.UPC_A.toString(), index, index*2, 1);
+                        BarcodeFormat.UPC_A.toString(), index, 1);
             }
 
             else {
                 id = db.insertLoyaltyCard("store" + index, "note" + index, "cardId" + index,
-                        BarcodeFormat.UPC_A.toString(), index, index*2, 0);
+                        BarcodeFormat.UPC_A.toString(), index, 0);
             }
             boolean result = (id != -1);
             assertTrue(result);
@@ -211,7 +210,6 @@ public class DatabaseTest
         assertEquals(BarcodeFormat.UPC_A.toString(), cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE)));
         assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS)));
         assertEquals(index, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR)));
-        assertEquals(index*2, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR)));
 
         cursor.moveToNext();
 
@@ -224,7 +222,6 @@ public class DatabaseTest
             assertEquals(BarcodeFormat.UPC_A.toString(), cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE)));
             assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS)));
             assertEquals(index, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR)));
-            assertEquals(index*2, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_TEXT_COLOR)));
 
             cursor.moveToNext();
         }
@@ -373,7 +370,7 @@ public class DatabaseTest
     {
         // Create card
         assertEquals(0, db.getLoyaltyCardCount());
-        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, DEFAULT_HEADER_TEXT_COLOR, 0);
+        long id = db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), DEFAULT_HEADER_COLOR, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, db.getLoyaltyCardCount());

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -70,7 +70,7 @@ public class ImportExportTest
         {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, index*2, 0);
+            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, 0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -86,7 +86,7 @@ public class ImportExportTest
         {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, index*2, 1);
+            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, 1);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -95,7 +95,7 @@ public class ImportExportTest
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
             //if index is even
-            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, index*2, 0);
+            long id = db.insertLoyaltyCard(storeName, note, BARCODE_DATA, BARCODE_TYPE, index, 0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -138,7 +138,6 @@ public class ImportExportTest
             assertEquals(BARCODE_DATA, card.cardId);
             assertEquals(BARCODE_TYPE, card.barcodeType);
             assertEquals(Integer.valueOf(index), card.headerColor);
-            assertEquals(Integer.valueOf(index*2), card.headerTextColor);
             assertEquals(0, card.starStatus);
 
             index++;
@@ -169,7 +168,6 @@ public class ImportExportTest
             assertEquals(BARCODE_DATA, card.cardId);
             assertEquals(BARCODE_TYPE, card.barcodeType);
             assertEquals(Integer.valueOf(index), card.headerColor);
-            assertEquals(Integer.valueOf(index*2), card.headerTextColor);
             assertEquals(1, card.starStatus);
 
             index++;
@@ -188,7 +186,6 @@ public class ImportExportTest
         assertEquals(BARCODE_DATA, card.cardId);
         assertEquals(BARCODE_TYPE, card.barcodeType);
         assertEquals(Integer.valueOf(index), card.headerColor);
-        assertEquals(Integer.valueOf(index*2), card.headerTextColor);
         assertEquals(0, card.starStatus);
 
         index++;
@@ -552,7 +549,6 @@ public class ImportExportTest
         assertEquals("type", card.barcodeType);
         assertEquals(0, card.starStatus);
         assertNull(card.headerColor);
-        assertNull(card.headerTextColor);
     }
 
     @Test
@@ -586,7 +582,6 @@ public class ImportExportTest
         assertEquals("type", card.barcodeType);
         assertEquals(0, card.starStatus);
         assertNull(card.headerColor);
-        assertNull(card.headerTextColor);
     }
 
     @Test
@@ -644,7 +639,6 @@ public class ImportExportTest
         assertEquals("", card.barcodeType);
         assertEquals(0, card.starStatus);
         assertEquals(1, (long) card.headerColor);
-        assertEquals(1, (long) card.headerTextColor);
     }
 
     @Test
@@ -678,7 +672,6 @@ public class ImportExportTest
         assertEquals("type", card.barcodeType);
         assertEquals(1, card.starStatus);
         assertEquals(1, (long) card.headerColor);
-        assertEquals(1, (long) card.headerTextColor);
     }
 
 
@@ -714,7 +707,6 @@ public class ImportExportTest
         assertEquals("type", card.barcodeType);
         assertEquals(0, card.starStatus);
         assertEquals(1, (long) card.headerColor);
-        assertEquals(1, (long) card.headerTextColor);
     }
 
     @Test
@@ -768,6 +760,5 @@ public class ImportExportTest
         assertEquals("type", card.barcodeType);
         assertEquals(0, card.starStatus);
         assertEquals(1, (long) card.headerColor);
-        assertEquals(1, (long) card.headerTextColor);
-        }
+    }
 }

--- a/app/src/test/java/protect/card_locker/ImportURITest.java
+++ b/app/src/test/java/protect/card_locker/ImportURITest.java
@@ -35,7 +35,7 @@ public class ImportURITest {
     public void ensureNoDataLoss() throws InvalidObjectException
     {
         // Generate card
-        db.insertLoyaltyCard("store", "note", BarcodeFormat.UPC_A.toString(), LoyaltyCardDbIds.BARCODE_TYPE, Color.BLACK, Color.WHITE, 1);
+        db.insertLoyaltyCard("store", "note", BarcodeFormat.UPC_A.toString(), LoyaltyCardDbIds.BARCODE_TYPE, Color.BLACK, 1);
 
         // Get card
         LoyaltyCard card = db.getLoyaltyCard(1);
@@ -50,7 +50,6 @@ public class ImportURITest {
         assertEquals(card.barcodeType, parsedCard.barcodeType);
         assertEquals(card.cardId, parsedCard.cardId);
         assertEquals(card.headerColor, parsedCard.headerColor);
-        assertEquals(card.headerTextColor, parsedCard.headerTextColor);
         assertEquals(card.note, parsedCard.note);
         assertEquals(card.store, parsedCard.store);
         // No export of starStatus for single cards foreseen therefore 0 will be imported
@@ -61,7 +60,7 @@ public class ImportURITest {
     public void ensureNoCrashOnMissingHeaderFields() throws InvalidObjectException
     {
         // Generate card
-        db.insertLoyaltyCard("store", "note", BarcodeFormat.UPC_A.toString(), LoyaltyCardDbIds.BARCODE_TYPE, null, null, 0);
+        db.insertLoyaltyCard("store", "note", BarcodeFormat.UPC_A.toString(), LoyaltyCardDbIds.BARCODE_TYPE, null, 0);
 
         // Get card
         LoyaltyCard card = db.getLoyaltyCard(1);
@@ -97,7 +96,7 @@ public class ImportURITest {
     {
         try {
             //"stare" instead of store
-            importURIHelper.parse(Uri.parse("https://brarcher.github.io/loyalty-card-locker/share?stare=store&note=note&cardid=12345&barcodetype=ITF&headercolor=-416706&headertextcolor=-1"));
+            importURIHelper.parse(Uri.parse("https://brarcher.github.io/loyalty-card-locker/share?stare=store&note=note&cardid=12345&barcodetype=ITF&headercolor=-416706"));
             assertTrue(false); // Shouldn't get here
         } catch(InvalidObjectException ex) {
             // Desired behaviour
@@ -120,7 +119,6 @@ public class ImportURITest {
         assertEquals("note", parsedCard.note);
         assertEquals("store", parsedCard.store);
         assertEquals(Integer.valueOf(-416706), parsedCard.headerColor);
-        assertEquals(Integer.valueOf(-1), parsedCard.headerTextColor);
         assertEquals(0, parsedCard.starStatus);
     }
 }

--- a/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
@@ -84,7 +84,7 @@ public class LoyaltyCardCursorAdapterTest
     @Test
     public void TestCursorAdapterEmptyNote()
     {
-        db.insertLoyaltyCard("store", "", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
         LoyaltyCard card = db.getLoyaltyCard(1);
 
         Cursor cursor = db.getLoyaltyCardCursor();
@@ -98,7 +98,7 @@ public class LoyaltyCardCursorAdapterTest
     @Test
     public void TestCursorAdapterWithNote()
     {
-        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
         LoyaltyCard card = db.getLoyaltyCard(1);
 
         Cursor cursor = db.getLoyaltyCardCursor();
@@ -112,7 +112,7 @@ public class LoyaltyCardCursorAdapterTest
     @Test
     public void TestCursorAdapterFontSizes()
     {
-        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
         LoyaltyCard card = db.getLoyaltyCard(1);
 
         Cursor cursor = db.getLoyaltyCardCursor();
@@ -130,9 +130,9 @@ public class LoyaltyCardCursorAdapterTest
     @Test
     public void TestCursorAdapterStarring()
     {
-        db.insertLoyaltyCard("storeA", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
-        db.insertLoyaltyCard("storeB", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 1);
-        db.insertLoyaltyCard("storeC", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 1);
+        db.insertLoyaltyCard("storeA", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
+        db.insertLoyaltyCard("storeB", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 1);
+        db.insertLoyaltyCard("storeC", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 1);
 
 
         Cursor cursor = db.getLoyaltyCardCursor();

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
-import static protect.card_locker.LoyaltyCardEditActivity.NO_BARCODE;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -130,7 +129,7 @@ public class LoyaltyCardViewActivityTest
         assertEquals(cardId, card.cardId);
 
         // The special "No barcode" string shouldn't actually be written to the loyalty card
-        if(barcodeType.equals(NO_BARCODE))
+        if(barcodeType.equals(activity.getApplicationContext().getString(R.string.noBarcode)))
         {
             assertEquals("", card.barcodeType);
         }
@@ -399,7 +398,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -415,7 +414,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -431,7 +430,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", EAN_BARCODE_DATA, EAN_BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", EAN_BARCODE_DATA, EAN_BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -452,7 +451,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", EAN_BARCODE_DATA, EAN_BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", EAN_BARCODE_DATA, EAN_BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -478,7 +477,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -522,7 +521,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -540,7 +539,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, null, null, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, null, 0);
 
         activityController.start();
         activityController.visible();
@@ -558,7 +557,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, null, null, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, null, 0);
 
         activityController.start();
         activityController.visible();
@@ -575,14 +574,14 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, "", Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, "", Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
         activityController.resume();
 
         // Save and check the loyalty card
-        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, NO_BARCODE, false);
+        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, activity.getApplicationContext().getString(R.string.noBarcode), false);
     }
 
     @Test
@@ -592,7 +591,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
 
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();
@@ -605,11 +604,11 @@ public class LoyaltyCardViewActivityTest
         selectBarcodeWithResult(activity, R.id.enterButton, BARCODE_DATA, "", true);
 
         // Check if the barcode type is NO_BARCODE as expected
-        checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, NO_BARCODE);
+        checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, activity.getApplicationContext().getString(R.string.noBarcode));
         assertEquals(View.GONE, activity.findViewById(R.id.barcodeLayout).getVisibility());
 
         // Check if the special NO_BARCODE string doesn't get saved
-        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, NO_BARCODE, false);
+        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, activity.getApplicationContext().getString(R.string.noBarcode), false);
     }
 
     @Test
@@ -619,7 +618,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         final int STORE_FONT_SIZE = 50;
         final int CARD_FONT_SIZE = 40;
@@ -661,7 +660,7 @@ public class LoyaltyCardViewActivityTest
 
             Activity activity = (Activity)activityController.get();
             DBHelper db = new DBHelper(activity);
-            db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+            db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
             SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(activity);
             settings.edit()
@@ -696,7 +695,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity) activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE,0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK,0);
         activityController.start();
         activityController.visible();
         activityController.resume();
@@ -725,7 +724,7 @@ public class LoyaltyCardViewActivityTest
 
         Activity activity = (Activity)activityController.get();
         DBHelper db = new DBHelper(activity);
-        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, 0);
 
         activityController.start();
         activityController.visible();

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -111,7 +111,7 @@ public class LoyaltyCardViewActivityTest
         final EditText storeField = activity.findViewById(R.id.storeNameEdit);
         final EditText noteField = activity.findViewById(R.id.noteEdit);
         final TextView cardIdField = activity.findViewById(R.id.cardIdView);
-        final TextView barcodeTypeField = activity.findViewById(R.id.barcodeTypeView);
+        final TextView barcodeTypeField = activity.findViewById(R.id.barcodeTypeField);
 
         storeField.setText(store);
         noteField.setText(note);
@@ -238,10 +238,9 @@ public class LoyaltyCardViewActivityTest
 
             checkFieldProperties(activity, R.id.storeNameEdit, editVisibility, store);
             checkFieldProperties(activity, R.id.noteEdit, editVisibility, note);
+            checkFieldProperties(activity, R.id.cardAndBarcodeLayout, cardId.isEmpty() ? View.GONE : View.VISIBLE, null);
             checkFieldProperties(activity, R.id.cardIdView, View.VISIBLE, cardId);
-            checkFieldProperties(activity, R.id.cardIdDivider, cardId.isEmpty() ? View.GONE : View.VISIBLE, null);
-            checkFieldProperties(activity, R.id.cardIdTableRow, cardId.isEmpty() ? View.GONE : View.VISIBLE, null);
-            checkFieldProperties(activity, R.id.barcodeTypeView, View.VISIBLE, barcodeType);
+            checkFieldProperties(activity, R.id.barcodeTypeField, View.VISIBLE, barcodeType);
             checkFieldProperties(activity, R.id.captureButton, captureVisibility, null);
             checkFieldProperties(activity, R.id.barcode, View.VISIBLE, null);
         }
@@ -258,7 +257,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
 
         checkAllFields(activity, ViewMode.ADD_CARD, "", "", "", "");
-        assertEquals(View.GONE, activity.findViewById(R.id.barcodeTypeTableRow).getVisibility());
+        assertEquals(View.GONE, activity.findViewById(R.id.cardAndBarcodeLayout).getVisibility());
     }
 
     @Test
@@ -607,7 +606,7 @@ public class LoyaltyCardViewActivityTest
 
         // Check if the barcode type is NO_BARCODE as expected
         checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, NO_BARCODE);
-        assertEquals(View.GONE, activity.findViewById(R.id.barcodeTypeTableRow).getVisibility());
+        assertEquals(View.GONE, activity.findViewById(R.id.barcodeLayout).getVisibility());
 
         // Check if the special NO_BARCODE string doesn't get saved
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, NO_BARCODE, false);
@@ -799,8 +798,7 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
 
         checkAllFields(activity, ViewMode.ADD_CARD, "Example Store", "", "123456", "AZTEC");
-        assertEquals(-416706, ((ColorDrawable) activity.findViewById(R.id.headingColorSample).getBackground()).getColor());
-        assertEquals(-1, ((ColorDrawable) activity.findViewById(R.id.headingStoreTextColorSample).getBackground()).getColor());
+        assertEquals(-416706, ((ColorDrawable) activity.findViewById(R.id.thumbnail).getBackground()).getColor());
     }
 
     @Test
@@ -820,7 +818,6 @@ public class LoyaltyCardViewActivityTest
         Activity activity = (Activity)activityController.get();
 
         checkAllFields(activity, ViewMode.ADD_CARD, "Example Store", "", "123456", "AZTEC");
-        assertEquals(-416706, ((ColorDrawable) activity.findViewById(R.id.headingColorSample).getBackground()).getColor());
-        assertEquals(-1, ((ColorDrawable) activity.findViewById(R.id.headingStoreTextColorSample).getBackground()).getColor());
+        assertEquals(-416706, ((ColorDrawable) activity.findViewById(R.id.thumbnail).getBackground()).getColor());
     }
 }

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -98,7 +98,7 @@ public class MainActivityTest
         assertEquals(0, list.getCount());
 
         DBHelper db = new DBHelper(mainActivity);
-        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("store", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
 
         assertEquals(View.VISIBLE, helpText.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -132,10 +132,10 @@ public class MainActivityTest
         assertEquals(0, list.getCount());
 
         DBHelper db = new DBHelper(mainActivity);
-        db.insertLoyaltyCard("storeB", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
-        db.insertLoyaltyCard("storeA", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
-        db.insertLoyaltyCard("storeD", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 1);
-        db.insertLoyaltyCard("storeC", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 1);
+        db.insertLoyaltyCard("storeB", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
+        db.insertLoyaltyCard("storeA", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
+        db.insertLoyaltyCard("storeD", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 1);
+        db.insertLoyaltyCard("storeC", "note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 1);
 
         assertEquals(View.VISIBLE, helpText.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -229,8 +229,8 @@ public class MainActivityTest
         TabLayout groupTabs = mainActivity.findViewById(R.id.groups);
 
         DBHelper db = new DBHelper(mainActivity);
-        db.insertLoyaltyCard("The First Store", "Initial note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
-        db.insertLoyaltyCard("The Second Store", "Secondary note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, Color.WHITE, 0);
+        db.insertLoyaltyCard("The First Store", "Initial note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
+        db.insertLoyaltyCard("The Second Store", "Secondary note", "cardId", BarcodeFormat.UPC_A.toString(), Color.BLACK, 0);
 
         db.insertGroup("Group one");
         List<Group> groups = new ArrayList<>();


### PR DESCRIPTION
Been working on improving the edit UI to get it ready for #45 and #8.

TODO:
- [x] Get rid of headingStoreTextColorValue (automatically base it on the background colour to have enough contrast)
- [ ] Fix positioning of the icon in the top left (it is just EVER so slightly misaligned)
- [x] Make card ID editable
- [x] Make barcode type selectable from dropdown

![image](https://user-images.githubusercontent.com/1885159/98594121-7e299e80-22d4-11eb-827d-f22322cf8349.png)