### PR TITLE
TargetSDK, Version Upgrades, Deprecations and XLint

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "me.hackerchick.catima"
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 84
-        versionName "2.6.1"
+        versionCode 83
+        versionName "2.6.0"
 
         vectorDrawables.useSupportLibrary true
         multiDexEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,15 +11,15 @@ spotbugs {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 31
+    buildToolsVersion "31.0.0"
 
     defaultConfig {
         applicationId "me.hackerchick.catima"
         minSdkVersion 19
-        targetSdkVersion 30
-        versionCode 83
-        versionName "2.6.0"
+        targetSdkVersion 31
+        versionCode 84
+        versionName "2.6.1"
 
         vectorDrawables.useSupportLibrary true
         multiDexEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         <activity
             android:name="protect.card_locker.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/SplashTheme">
+            android:theme="@style/SplashTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
@@ -92,7 +93,8 @@
         <activity
             android:name=".CardShortcutConfigure"
             android:label="@string/cardShortcut"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -12,6 +12,7 @@ import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.graphics.ImageDecoder;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -1087,7 +1088,12 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity
             } else if (requestCode == Utils.CARD_IMAGE_FROM_FILE_FRONT || requestCode == Utils.CARD_IMAGE_FROM_FILE_BACK) {
                 Bitmap bitmap = null;
                 try {
-                    bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), intent.getData());
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                        bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), intent.getData());
+                    } else {
+                        ImageDecoder.Source image_source = ImageDecoder.createSource(getContentResolver(), intent.getData());
+                        bitmap = ImageDecoder.decodeBitmap(image_source, (decoder, info, source) -> decoder.setMutableRequired(true));
+                    }
                 } catch (IOException e) {
                     Log.e(TAG, "Error getting data from image file");
                     e.printStackTrace();

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1088,11 +1088,11 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity
             } else if (requestCode == Utils.CARD_IMAGE_FROM_FILE_FRONT || requestCode == Utils.CARD_IMAGE_FROM_FILE_BACK) {
                 Bitmap bitmap = null;
                 try {
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                        bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), intent.getData());
-                    } else {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         ImageDecoder.Source image_source = ImageDecoder.createSource(getContentResolver(), intent.getData());
                         bitmap = ImageDecoder.decodeBitmap(image_source, (decoder, info, source) -> decoder.setMutableRequired(true));
+                    } else {
+                        bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), intent.getData());
                     }
                 } catch (IOException e) {
                     Log.e(TAG, "Error getting data from image file");

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -45,6 +45,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.Guideline;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.widget.TextViewCompat;
 import protect.card_locker.preferences.Settings;
@@ -192,7 +193,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         Drawable unwrappedIcon = AppCompatResources.getDrawable(this, active ? R.drawable.active_dot : R.drawable.inactive_dot);
         assert unwrappedIcon != null;
         Drawable wrappedIcon = DrawableCompat.wrap(unwrappedIcon);
-        DrawableCompat.setTint(wrappedIcon, getResources().getColor(R.color.iconColor));
+        DrawableCompat.setTint(wrappedIcon, ContextCompat.getColor(getApplicationContext(), R.color.iconColor));
 
         return wrappedIcon;
     }
@@ -468,7 +469,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             int expiryString = R.string.expiryStateSentence;
             if(Utils.hasExpired(loyaltyCard.expiry)) {
                 expiryString = R.string.expiryStateSentenceExpired;
-                expiryView.setTextColor(getResources().getColor(R.color.alert));
+                expiryView.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.alert));
             }
             expiryView.setText(getString(expiryString, DateFormat.getDateInstance(DateFormat.LONG).format(loyaltyCard.expiry)));
             expiryView.setTextSize(settings.getFontSizeMax(settings.getMediumFont()));

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -106,11 +106,11 @@ public class Utils {
 
             Bitmap bitmap;
             try {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                    bitmap = MediaStore.Images.Media.getBitmap(context.getContentResolver(), intent.getData());
-                } else {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     ImageDecoder.Source image_source = ImageDecoder.createSource(context.getContentResolver(), intent.getData());
                     bitmap = ImageDecoder.decodeBitmap(image_source, (decoder, info, source) -> decoder.setMutableRequired(true));
+                } else {
+                    bitmap = MediaStore.Images.Media.getBitmap(context.getContentResolver(), intent.getData());
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting data from image file");

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -8,6 +8,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.graphics.ImageDecoder;
 import android.graphics.Matrix;
 import android.os.Build;
 import android.os.LocaleList;
@@ -105,7 +106,12 @@ public class Utils {
 
             Bitmap bitmap;
             try {
-                bitmap = MediaStore.Images.Media.getBitmap(context.getContentResolver(), intent.getData());
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    bitmap = MediaStore.Images.Media.getBitmap(context.getContentResolver(), intent.getData());
+                } else {
+                    ImageDecoder.Source image_source = ImageDecoder.createSource(context.getContentResolver(), intent.getData());
+                    bitmap = ImageDecoder.decodeBitmap(image_source, (decoder, info, source) -> decoder.setMutableRequired(true));
+                }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting data from image file");
                 e.printStackTrace();

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.0'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -23,6 +23,9 @@ allprojects {
         mavenCentral()
         maven { url "https://jitpack.io" }
         gradlePluginPortal()
+    }
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:deprecation"
     }
 }
 


### PR DESCRIPTION
Bump targetSDK and buildtools
Bump Gradle Version
Bump Application Version

Android 11: android:exported=" must now be set in the Manifest for Intents

Enable -Xlint:deprecation default (Warn)

Replace some Deprecations:

getBitmap (Deprecated in 29) with ImageDecoder
(Tested on Emulator and Lineage 18)

getColor with ContextCompat.getColor (23 and up)
Sadly i do NOT have a real Android < 23 device to test that but works in a KitKat Emulator.
