### PR TITLE
Removed click listener from card icon

### DIFF
--- a/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
+++ b/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
@@ -76,10 +76,6 @@ public class CardShortcutConfigure extends AppCompatActivity implements LoyaltyC
         finish();
     }
 
-    @Override
-    public void onIconClicked(int inputPosition) {
-        onClickAction(inputPosition);
-    }
 
     @Override
     public void onRowClicked(int inputPosition) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -128,7 +128,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     private void applyClickEvents(LoyaltyCardListItemViewHolder inputHolder, final int inputPosition)
     {
-        inputHolder.mThumbnailContainer.setOnClickListener(inputView -> mListener.onIconClicked(inputPosition));
+        //inputHolder.mThumbnailContainer.setOnClickListener(inputView -> mListener.onIconClicked(inputPosition));
         inputHolder.mRow.setOnClickListener(inputView -> mListener.onRowClicked(inputPosition));
         inputHolder.mInformationContainer.setOnClickListener(inputView -> mListener.onRowClicked(inputPosition));
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -128,7 +128,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     private void applyClickEvents(LoyaltyCardListItemViewHolder inputHolder, final int inputPosition)
     {
-        //inputHolder.mThumbnailContainer.setOnClickListener(inputView -> mListener.onIconClicked(inputPosition));
         inputHolder.mRow.setOnClickListener(inputView -> mListener.onRowClicked(inputPosition));
         inputHolder.mInformationContainer.setOnClickListener(inputView -> mListener.onRowClicked(inputPosition));
 
@@ -238,7 +237,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     public interface CardAdapterListener
     {
-        void onIconClicked(int inputPosition);
         void onRowClicked(int inputPosition);
         void onRowLongClicked(int inputPosition);
     }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -247,7 +247,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         public TextView mStoreField, mNoteField, mBalanceField, mExpiryField;
         public LinearLayout mInformationContainer;
         public ImageView mCardIcon, mStarIcon;
-        public CardView mThumbnailContainer;
         public MaterialCardView mRow;
         public View mDivider;
         public RelativeLayout mThumbnailFrontContainer, mThumbnailBackContainer;
@@ -255,7 +254,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         public LoyaltyCardListItemViewHolder(View inputView)
         {
             super(inputView);
-            mThumbnailContainer = inputView.findViewById(R.id.thumbnail_container);
             mRow = inputView.findViewById(R.id.row);
             mDivider = inputView.findViewById(R.id.info_divider);
             mThumbnailFrontContainer = inputView.findViewById(R.id.thumbnail_front);

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -715,16 +715,6 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         }
     }
 
-    @Override
-    public void onIconClicked(int inputPosition)
-    {
-        if (mCurrentActionMode == null)
-        {
-            mCurrentActionMode = startSupportActionMode(mCurrentActionModeCallback);
-        }
-
-        toggleSelection(inputPosition);
-    }
 
     @Override
     public void onRowClicked(int inputPosition)


### PR DESCRIPTION
#449 
-  After removing the additional click listener in card icon, clicking the card icon itself works just like clicking in the rest of the card.

<table><tr>
<td>
<img src="https://user-images.githubusercontent.com/67424137/135848914-333507dd-bc99-45bb-8c7e-768c9767541f.png" width="200"></td>
<td>
<img src="https://user-images.githubusercontent.com/67424137/135849073-b027a838-787b-40d4-8cf4-5655d2836d51.png" width="200"></td></tr>
</table>
