### PR TITLE
Additional Norwegian translations

### DIFF
--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -40,9 +40,9 @@
     <string name="importOptionFilesystemTitle">Importer fra filsystem</string>
     <string name="importOptionFilesystemExplanation">Velg spesifikk fil fra filsystemet.</string>
     <string name="importOptionFilesystemButton">Fra filsystem</string>
-    <string name="importOptionApplicationTitle">Bruk et annet program</string>
-    <string name="importOptionApplicationExplanation">Bruk hvilket som helst program, eller din favoritt-filutforsker for å åpne en fil.</string>
-    <string name="importOptionApplicationButton">Bruk et annet program</string>
+    <string name="importOptionApplicationTitle">Bruk en annen app</string>
+    <string name="importOptionApplicationExplanation">Bruk en hvilken som helst app, eller din favoritt-filutforsker for å åpne en fil.</string>
+    <string name="importOptionApplicationButton">Bruk en annen app</string>
     <string name="about">Om</string>
     <string name="app_license">Gemenhetslig fri programvare, lisensiert GPLv3+.</string>
     <string name="about_title_fmt">Om <xliff:g id="app_name">%s</xliff:g></string>
@@ -74,13 +74,13 @@
     <string name="unstar">Fjern fra favoritter</string>
     <string name="star">Legg til i favoritter</string>
     <string name="noGroups">Klikk på «+»- (pluss)-tegnet for å legge til grupper for kategorisering først.</string>
-    <string name="deleteConfirmationGroup">Slett gruppe\?</string>
+    <string name="deleteConfirmationGroup">Slett gruppe?</string>
     <string name="all">Alle</string>
     <string name="groups">Grupper</string>
     <string name="enter_group_name">Skriv inn gruppenavn</string>
     <string name="noBarcode">Ingen strekkode</string>
     <string name="failedOpeningFileManager">Installer en filbehandler først.</string>
-    <string name="leaveWithoutSaveConfirmation">Forlat uten å lagre\?</string>
+    <string name="leaveWithoutSaveConfirmation">Forlat uten å lagre?</string>
     <string name="leaveWithoutSaveTitle">Avslutt</string>
     <string name="addManually">Skriv inn kort-ID manuelt</string>
     <string name="moveDown">Flytt nedover</string>
@@ -106,7 +106,7 @@
     <string name="balance">Saldo</string>
     <string name="balancePoints"><xliff:g>%s</xliff:g> poeng</string>
     <string name="balanceSentence">Saldo: <xliff:g>%s</xliff:g></string>
-    <string name="chooseImportType">Importer data fra\?</string>
+    <string name="chooseImportType">Importer data fra?</string>
     <string name="app_loyalty_card_keychain">Kundekortknippe</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Forhindre skjermlås</string>
     <string name="settings_keep_screen_on">Behold skjerm påslått</string>
@@ -132,8 +132,6 @@
     <string name="importLoyaltyCardKeychain">Importer fra Kundekortknippe</string>
     <string name="importFidmeMessage">Velg din <i>fidme-eksport-be-xxxxxx.zip</i> eksporter fra FidMe til å importere, og velg strekkode typer manuelt etterpå.
 \nEller lage den fra FidMe profil ved å velge Beskyttelse av Data og deretter trykke Trekke ut dataene mine første.</string>
-    <string name="importCatimaMessage">Finn en fil som antagelig heter <i>Catima.csv</i> å importere.
-\nEller opprett den i Import/eksport-menyen i et annet Catima-program ved å trykke «Eksporter» der først.</string>
     <string name="settings_max_font_size_scale">Maks. skriftstørrelse</string>
     <string name="wrongValueForBarcodeType">Verdien er ikke gyldig for valgt strekkodetype</string>
     <string name="intent_import_card_from_url_share_multiple_text">Jeg vil dele noen kort med deg</string>
@@ -142,10 +140,10 @@
     <string name="app_libraries">Frie tredjepartsbibliotek: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="card_ids_copied">Kopierte kort-ID(er)</string>
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Opphavsrett © 2019–<xliff:g>%d</xliff:g> Sylvia van Os.</string>
-    <string name="updateBarcodeQuestionText">Du har endret kortets ID. Ønsker du å også oppdatere strekkoden til samme verdi\?</string>
+    <string name="updateBarcodeQuestionText">Du har endret kortets ID. Ønsker du å også oppdatere strekkoden til samme verdi?</string>
     <string name="no">Nei</string>
     <string name="yes">Ja</string>
-    <string name="updateBarcodeQuestionTitle">Oppdater strekkodeverdi\?</string>
+    <string name="updateBarcodeQuestionTitle">Oppdater strekkodeverdi?</string>
     <string name="takePhoto">Ta et bilde</string>
     <string name="removeImage">Fjern bilde</string>
     <string name="setBackImage">Sett bakside</string>
@@ -162,10 +160,10 @@
         <item quantity="one"><xliff:g>%d</xliff:g> kort valgt</item>
         <item quantity="other"><xliff:g>%d</xliff:g> korten valgt</item>
     </plurals>
-    <string name="deleteConfirmation">Slett dette kortet for godt\?</string>
+    <string name="deleteConfirmation">Slett dette kortet for godt?</string>
     <plurals name="deleteCardsConfirmation">
-        <item quantity="one">Slett dette kortet for godt\?</item>
-        <item quantity="other">Slett disse <xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">%s</xliff:g> kortene for godt\?</item>
+        <item quantity="one">Slett dette kortet for godt?</item>
+        <item quantity="other">Slett disse <xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">%s</xliff:g> kortene for godt?</item>
     </plurals>
     <string name="turn_flashlight_on">Skru på lommelykten</string>
     <string name="turn_flashlight_off">Skru av lommelykten</string>
@@ -198,4 +196,14 @@
     <string name="sort_by_most_recently_used">Nyligst brukt</string>
     <string name="sort_by_name">Navn</string>
     <string name="sort">Sorter</string>
+    <string name="help_translate_this_app">Hjelp med å oversette denne appen</string>
+    <string name="license">Lisens</string>
+    <string name="version_history">Versjonshistorikk</string>
+    <string name="importCatimaMessage">Velg din <i>catima.zip</i> fra Catima å importere. Eller lag den fra Importer/Eksporter-menyen i en annen Catima-app ved å trykke på \"Eksporter\" der først</string>
+    <string name="source_repository">Kildekode</string>
+    <string name="on_github">på GitHub</string>
+    <string name="and_data_usage">og bruk av data</string>
+    <string name="rate_this_app">Vurder denne appen</string>
+    <string name="on_google_play">på Google Play</string>
+    <string name="report_error">Rapporter feil</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -11,7 +11,7 @@
     <string name="edit">Rediger</string>
     <string name="delete">Slett</string>
     <string name="confirm">Bekreft</string>
-    <string name="lockScreen">Ingen rotering</string>
+    <string name="lockScreen">Skru av rotering</string>
     <string name="unlockScreen">Skru på rotering</string>
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Kopier ID til utklippstavle</string>
@@ -24,7 +24,7 @@
     <string name="noStoreError">Navn ikke angitt</string>
     <string name="noCardIdError">Ingen kort-ID innskrevet</string>
     <string name="noCardExistsError">Kunne ikke finne kort</string>
-    <string name="importExport">Import/eksport</string>
+    <string name="importExport">Importer/eksporter</string>
     <string name="exportName">Eksporter</string>
     <string name="importExportHelp">Sikkerhetskopiering av kort lar deg flytte dem til en annen enhet.</string>
     <string name="importSuccessfulTitle">Importert</string>
@@ -112,7 +112,7 @@
     <string name="settings_keep_screen_on">Behold skjerm påslått</string>
     <string name="privacy_policy_popup_text">Personvernspraksis-notis (påkrevd av noen programbutikker):
 \n
-\nINGEN DATA SAMLES INN, noe alle kan bekreftes siden programmet vårt er fri programvare.</string>
+\nINGEN DATA SAMLES INN I DET HELE TATT, noe alle kan bekreftes siden programmet vårt er fri programvare.</string>
     <string name="accept">Godta</string>
     <string name="privacy_policy">Personvernspraksis</string>
     <string name="importFidme">Importer fra FidMe</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -44,7 +44,7 @@
     <string name="importOptionApplicationExplanation">Bruk en hvilken som helst app, eller din favoritt-filutforsker for å åpne en fil.</string>
     <string name="importOptionApplicationButton">Bruk en annen app</string>
     <string name="about">Om</string>
-    <string name="app_license">Gemenhetslig fri programvare, lisensiert GPLv3+.</string>
+    <string name="app_license">Copyleft fri programvare, lisensiert under GPLv3+.</string>
     <string name="about_title_fmt">Om <xliff:g id="app_name">%s</xliff:g></string>
     <string name="debug_version_fmt">Versjon: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Utgivelsesinfo: <xliff:g id="app_revision_url">%s</xliff:g></string>

--- a/fastlane/metadata/android/nb-NO/changelogs/70.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/70.txt
@@ -1,0 +1,11 @@
+- INKOMPATIBEL ENDRING: Backup-formatet har blitt endret. Se https://github.com/TheLastProject/Catima/wiki/Export-format
+- INKOMPATIBEL ENDRING: Formatet for URL-deling har blitt endret. Se see https://github.com/TheLastProject/Catima/wiki/Card-sharing-URL-format
+- Gjør det mulig å skru av eller på blitsen under scanning
+- Legg til støtte for UPC-E
+- Støtte for å legge til et bilde av forside og bakside av hvert kort
+- Støtte for å importere passord-beskyttede zip filer
+- Støtte for importering fra Stocard (Beta)
+- Fiks ubrukelig mellomrom i notater fra Fidme-import
+- Støtt nytt Vaucher Vault eksportformat
+- Fiks at Floating Action Buttons ble skjult bak andre brukergrensesnitt-komponenter på Android 4
+- Fiks topp-margin i appbar ved visning av kundekort.

--- a/fastlane/metadata/android/nb-NO/changelogs/71.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/71.txt
@@ -1,0 +1,2 @@
+- Flere mindre oversettelser og forbedringer av brukergrensesnitt
+- Fiks krasj ved importering/deling av kundekort på Android 6

--- a/fastlane/metadata/android/nb-NO/changelogs/72.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/72.txt
@@ -1,0 +1,1 @@
+- Gjør det mulig å konfigurere bilde i nye kundekort

--- a/fastlane/metadata/android/nb-NO/changelogs/73.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/73.txt
@@ -1,0 +1,1 @@
+- Fiks innlasting av bilder ved redigering av et eksisterende kort

--- a/fastlane/metadata/android/nb-NO/changelogs/74.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/74.txt
@@ -1,0 +1,3 @@
+- Fiks oppretting av snarveier
+- Generer kort-spesifikke ikoner for snarveier
+- Fiks muligheten til å endre kundekort-farge

--- a/fastlane/metadata/android/nb-NO/changelogs/75.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/75.txt
@@ -1,0 +1,4 @@
+- Fiks valgt farge i fargebytte-dialogen
+- Støtte for å slette flere kort samtidig
+- Fiks mulig ArithmeticException når et bilde skaleres
+- Fiks at fullskjerm lukkes når enheten roteres

--- a/fastlane/metadata/android/nb-NO/changelogs/76.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/76.txt
@@ -1,0 +1,4 @@
+- Gjør linker i notater mulig å klikke
+- Forhåndsvelg gruppen brukeren er i når et nytt kort legges til
+- Komma-separerte gruppenavn i kundekort-visning
+- Fiks at maksimerings-knappen ble vist uten en strekkode

--- a/fastlane/metadata/android/nb-NO/changelogs/77.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/77.txt
@@ -1,0 +1,4 @@
+- Forbedre Stokard-importerer
+- Fiks importering av Catima-eksport med en notat over flere linjer
+- Skaler korttittel i et akseptabelt område
+- Forbedring av animasjoner

--- a/fastlane/metadata/android/nb-NO/changelogs/78.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/78.txt
@@ -1,0 +1,1 @@
+- Fiks krasj ved rotasjon i kundekortredigeringsaktiviteten

--- a/fastlane/metadata/android/nb-NO/changelogs/79.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/79.txt
@@ -1,0 +1,2 @@
+- Fiks widget som lager en snarvei som ser annerledes ut enn app-snarveier
+- Erstatt standard svart Android skjerm med en oppstartsskjerm

--- a/fastlane/metadata/android/nb-NO/changelogs/80.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/80.txt
@@ -1,0 +1,2 @@
+- Fiks at bilder ikke ble importert fra sikkerhetskopiering
+- Innstilling for å overstyre språk

--- a/fastlane/metadata/android/nb-NO/changelogs/81.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/81.txt
@@ -1,0 +1,4 @@
+- Forbedre kortliste for liggende modus, og nettbrett
+- Legg til støtte for fargetemaer (takk, Subhashish Anand!)
+- Ikke lukk scan-aktiviteten ved en kamerafeil (slik at å legge til manuelt fortsatt er mulig)
+- Legg til alle bidragsytere til om-dialogen

--- a/fastlane/metadata/android/nb-NO/changelogs/82.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/82.txt
@@ -1,0 +1,4 @@
+- Forbedret støtte for skjermlesere
+- Ikke krasj når man en video åpnes fra galleriet
+- Støtte for sveiping på skjermen for visning av kundekort
+- Ikke reset gruppe når tilbakeknapp trykkes

--- a/fastlane/metadata/android/nb-NO/changelogs/85.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/85.txt
@@ -1,0 +1,4 @@
+Android 4.4 er ikke lengre støttet fra og med denne versjonen. Hvis du vil bruke Catima på Android 4.4, bruk versjon 2.6.1.
+
+- Forbedret støtte for Android 12
+- Forbedret om-skjerm


### PR DESCRIPTION
Primarily includes translations to most of the untranslated strings (except `credits` because I've been blanking on the translation for a solid hour), several changelogs (all the way back to 70, including 85 -- just saw that's not released yet though. Also saw it's present in the english directory, so I assumed it was fine to include this), and a few changes to a couple of the existing translations for consistency, using modern or contextually accurate words, or for [a word](https://github.com/TheLastProject/Catima/commit/fb95c8c9d40bc42cc9df856679da9bd30417fbf4) that has absolutely [no record of being used like that](https://no.wikipedia.org/w/index.php?search=Gemenhetslig&title=Spesial%3AS%C3%B8k&go=G%C3%A5&ns0=1) [in any context of significance](https://ordbok.uib.no/perl/ordbok.cgi?OPP=Gemenhetslig&ant_bokmaal=5&ant_nynorsk=5&begge=+&ordbok=begge) aside [30 google results](https://www.google.com/search?q=Gemenhetslig&filter=0&biw=1920&bih=967&dpr=1) of more or less exclusively Android apps that presumably have some degree of automatic translation involved.

Also unescapes a few backslashes - they weren't escaped in the english source file, so I assume this is a web export artefact. 

... and also updated an old message talking about Catima.csv, which hasn't been a thing for several versions anyway