### PR TITLE
[Suggestion] Made fullscreen button color match the card

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -516,6 +516,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         appBarLayout.setBackgroundColor(backgroundHeaderColor);
         maximizeButton.setBackgroundColor(backgroundHeaderColor);
         minimizeButton.setBackgroundColor(backgroundHeaderColor);
+        bottomSheetButton.setBackgroundColor(backgroundHeaderColor);
 
         int textColor;
         if(Utils.needsDarkForeground(backgroundHeaderColor))
@@ -529,6 +530,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         storeName.setTextColor(textColor);
         maximizeButton.getDrawable().setTint(textColor);
         minimizeButton.getDrawable().setTint(textColor);
+        bottomSheetButton.getDrawable().setTint(textColor);
         ((Toolbar) findViewById(R.id.toolbar_landscape)).setTitleTextColor(textColor);
 
         // If the background is very bright, we should use dark icons

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -514,6 +514,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         collapsingToolbarLayout.setBackgroundColor(backgroundHeaderColor);
         appBarLayout.setBackgroundColor(backgroundHeaderColor);
+        maximizeButton.setBackgroundColor(backgroundHeaderColor);
 
         int textColor;
         if(Utils.needsDarkForeground(backgroundHeaderColor))
@@ -525,6 +526,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             textColor = Color.WHITE;
         }
         storeName.setTextColor(textColor);
+        maximizeButton.getDrawable().setTint(textColor);
         ((Toolbar) findViewById(R.id.toolbar_landscape)).setTitleTextColor(textColor);
 
         // If the background is very bright, we should use dark icons

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -515,6 +515,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         collapsingToolbarLayout.setBackgroundColor(backgroundHeaderColor);
         appBarLayout.setBackgroundColor(backgroundHeaderColor);
         maximizeButton.setBackgroundColor(backgroundHeaderColor);
+        minimizeButton.setBackgroundColor(backgroundHeaderColor);
 
         int textColor;
         if(Utils.needsDarkForeground(backgroundHeaderColor))
@@ -527,6 +528,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         }
         storeName.setTextColor(textColor);
         maximizeButton.getDrawable().setTint(textColor);
+        minimizeButton.getDrawable().setTint(textColor);
         ((Toolbar) findViewById(R.id.toolbar_landscape)).setTitleTextColor(textColor);
 
         // If the background is very bright, we should use dark icons


### PR DESCRIPTION
Hi again! The red (default color) fullscreen button really bothered me for some reason, so I made it follow the color scheme. I figured I'd send a PR in case you preferred it as well. Ideally, this could be done at the theme level, but that sounds like hell without [Paris](https://github.com/airbnb/paris), so i just changed the color for the element like you already do for the title bar.

Light & dark test:

![image](https://user-images.githubusercontent.com/3891092/139111323-7c2e1dbd-68e0-4ec2-b924-174c5727a888.png)
![image](https://user-images.githubusercontent.com/3891092/139111356-860e2347-16a4-4e66-8e3a-e10e040daa54.png)
