### PR TITLE
preserve shortcut icon shape by padding, getting round corners back on card lists

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.Outline;
 import android.graphics.drawable.Drawable;
 import android.util.SparseBooleanArray;
 import android.util.TypedValue;
@@ -12,6 +13,7 @@ import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -72,6 +74,15 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
     public void onBindViewHolder(LoyaltyCardListItemViewHolder inputHolder, Cursor inputCursor) {
         // Invisible until we want to show something more
         inputHolder.mDivider.setVisibility(View.GONE);
+
+        // remove outline shadow
+        inputHolder.mThumbnailContainer.setOutlineProvider(new ViewOutlineProvider() {
+            @Override
+            public void getOutline(View view, Outline outline) {
+                ViewOutlineProvider.BACKGROUND.getOutline(view, outline);
+                outline.setAlpha(0f);
+            }
+        });
 
         int size = mSettings.getFontSizeMax(mSettings.getSmallFont());
 
@@ -279,11 +290,13 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         public MaterialCardView mRow;
         public View mDivider;
         public RelativeLayout mThumbnailFrontContainer, mThumbnailBackContainer;
+        public MaterialCardView mThumbnailContainer;
 
         public LoyaltyCardListItemViewHolder(View inputView, CardAdapterListener inputListener) {
             super(inputView);
             mRow = inputView.findViewById(R.id.row);
             mDivider = inputView.findViewById(R.id.info_divider);
+            mThumbnailContainer = inputView.findViewById(R.id.thumbnail_container);
             mThumbnailFrontContainer = inputView.findViewById(R.id.thumbnail_front);
             mThumbnailBackContainer = inputView.findViewById(R.id.thumbnail_back);
             mInformationContainer = inputView.findViewById(R.id.information_container);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1284,6 +1284,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
 
         db.setLoyaltyCardGroups(loyaltyCardId, selectedGroups);
 
+        ShortcutHelper.updateShortcuts(this, db.getLoyaltyCard(loyaltyCardId));
+
         finish();
     }
 

--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -3,8 +3,10 @@ package protect.card_locker;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.os.Bundle;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -12,7 +14,10 @@ import java.util.List;
 
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
+import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.IconCompat;
+
+import org.jetbrains.annotations.NotNull;
 
 class ShortcutHelper {
     // Android documentation says that no more than 5 shortcuts
@@ -21,6 +26,14 @@ class ShortcutHelper {
     // to 3 here, so that the most recent shortcut has a good
     // chance of being shown.
     private static final int MAX_SHORTCUTS = 3;
+
+    // https://developer.android.com/reference/android/graphics/drawable/AdaptiveIconDrawable.html
+    private static final int ADAPTIVE_BITMAP_SCALE = 1;
+    private static final int ADAPTIVE_BITMAP_SIZE = 108 * ADAPTIVE_BITMAP_SCALE;
+    private static final int ADAPTIVE_BITMAP_VISIBLE_SIZE = 72 * ADAPTIVE_BITMAP_SCALE;
+    private static final int ADAPTIVE_BITMAP_IMAGE_SIZE = ADAPTIVE_BITMAP_VISIBLE_SIZE + 5 * ADAPTIVE_BITMAP_SCALE;
+    private static final int PADDING_COLOR = Color.argb(255, 255, 255, 255);
+    private static final int PADDING_COLOR_OVERLAY = Color.argb(127, 0, 0, 0);
 
     /**
      * Add a card to the app shortcuts, and maintain a list of the most
@@ -106,6 +119,22 @@ class ShortcutHelper {
         ShortcutManagerCompat.setDynamicShortcuts(context, list);
     }
 
+    static @NotNull Bitmap createAdaptiveBitmap(@NotNull Bitmap in, int paddingColor){
+        int[] basePixels = new int[ADAPTIVE_BITMAP_SIZE * ADAPTIVE_BITMAP_SIZE];
+        paddingColor = ColorUtils.compositeColors(PADDING_COLOR_OVERLAY, paddingColor);
+        Arrays.fill(basePixels, paddingColor);
+        Bitmap ret = Bitmap.createBitmap(ADAPTIVE_BITMAP_SIZE, ADAPTIVE_BITMAP_SIZE, Bitmap.Config.ARGB_8888);
+        ret.setPixels(basePixels, 0, ADAPTIVE_BITMAP_SIZE, 0, 0, ADAPTIVE_BITMAP_SIZE, ADAPTIVE_BITMAP_SIZE);
+        Bitmap resized = Utils.resizeBitmap(in, ADAPTIVE_BITMAP_IMAGE_SIZE);
+        int[] inputPixels = new int[resized.getHeight() * resized.getWidth()];
+        resized.getPixels(inputPixels, 0, resized.getWidth(), 0, 0, resized.getWidth(), resized.getHeight());
+        for(int i = 0;i < inputPixels.length; i++) {
+            inputPixels[i] = ColorUtils.compositeColors(inputPixels[i], paddingColor);
+        }
+        ret.setPixels(inputPixels, 0, resized.getWidth(), (ADAPTIVE_BITMAP_SIZE - resized.getWidth()) / 2, (ADAPTIVE_BITMAP_SIZE - resized.getHeight()) / 2, resized.getWidth(), resized.getHeight());
+        return ret;
+    }
+
     static ShortcutInfoCompat.Builder createShortcutBuilder(Context context, LoyaltyCard loyaltyCard) {
         Intent intent = new Intent(context, LoyaltyCardViewActivity.class);
         intent.setAction(Intent.ACTION_MAIN);
@@ -120,6 +149,8 @@ class ShortcutHelper {
         Bitmap iconBitmap = Utils.retrieveCardImage(context, loyaltyCard.id, ImageLocationType.icon);
         if (iconBitmap == null) {
             iconBitmap = Utils.generateIcon(context, loyaltyCard, true).getLetterTile();
+        }else{
+            iconBitmap = createAdaptiveBitmap(iconBitmap, loyaltyCard.headerColor == null ? PADDING_COLOR : loyaltyCard.headerColor);
         }
 
         IconCompat icon = IconCompat.createWithAdaptiveBitmap(iconBitmap);

--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -3,6 +3,7 @@ package protect.card_locker;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.os.Bundle;
 
@@ -120,18 +121,11 @@ class ShortcutHelper {
     }
 
     static @NotNull Bitmap createAdaptiveBitmap(@NotNull Bitmap in, int paddingColor){
-        int[] basePixels = new int[ADAPTIVE_BITMAP_SIZE * ADAPTIVE_BITMAP_SIZE];
-        paddingColor = ColorUtils.compositeColors(PADDING_COLOR_OVERLAY, paddingColor);
-        Arrays.fill(basePixels, paddingColor);
         Bitmap ret = Bitmap.createBitmap(ADAPTIVE_BITMAP_SIZE, ADAPTIVE_BITMAP_SIZE, Bitmap.Config.ARGB_8888);
-        ret.setPixels(basePixels, 0, ADAPTIVE_BITMAP_SIZE, 0, 0, ADAPTIVE_BITMAP_SIZE, ADAPTIVE_BITMAP_SIZE);
+        Canvas output = new Canvas(ret);
+        output.drawColor(ColorUtils.compositeColors(PADDING_COLOR_OVERLAY, paddingColor));
         Bitmap resized = Utils.resizeBitmap(in, ADAPTIVE_BITMAP_IMAGE_SIZE);
-        int[] inputPixels = new int[resized.getHeight() * resized.getWidth()];
-        resized.getPixels(inputPixels, 0, resized.getWidth(), 0, 0, resized.getWidth(), resized.getHeight());
-        for(int i = 0;i < inputPixels.length; i++) {
-            inputPixels[i] = ColorUtils.compositeColors(inputPixels[i], paddingColor);
-        }
-        ret.setPixels(inputPixels, 0, resized.getWidth(), (ADAPTIVE_BITMAP_SIZE - resized.getWidth()) / 2, (ADAPTIVE_BITMAP_SIZE - resized.getHeight()) / 2, resized.getWidth(), resized.getHeight());
+        output.drawBitmap(resized, (ADAPTIVE_BITMAP_SIZE - resized.getWidth()) / 2f, (ADAPTIVE_BITMAP_SIZE - resized.getHeight()) / 2f, null);
         return ret;
     }
 

--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -32,8 +32,7 @@
                     app:cardCornerRadius="4dp"
                     android:layout_alignParentStart="true"
                     android:layout_centerVertical="true"
-                    app:cardBackgroundColor="@android:color/transparent"
-                    android:outlineProvider="none">
+                    app:cardBackgroundColor="@android:color/transparent">
 
                     <RelativeLayout
                         android:id="@+id/thumbnail_front"


### PR DESCRIPTION
adding padding to icons referencing https://developer.android.com/reference/android/graphics/drawable/AdaptiveIconDrawable.html
![image](https://user-images.githubusercontent.com/22017945/140962982-88becacc-677d-4593-8b7e-15fcc2f9df7e.png)
![image](https://user-images.githubusercontent.com/22017945/140889147-a40ea4ed-5fb1-47b8-9ec1-59bab7d6577f.png)

